### PR TITLE
Update installation guide for MacBook-based deployment using k3sup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,19 +2,19 @@
 
 ## Prerequisites
 
-### Hardware Requirements
+### Local Machine Requirements (MacBook)
+- macOS with Terminal access
+- SSH access to all k3s nodes
+
+### Remote Node Requirements
 - 3 nodes with at least:
   - 2 CPU cores per node
   - 2GB RAM per node
   - 20GB storage per node
-
-### Software Requirements
-- Linux OS on all nodes (tested with Ubuntu Server 22.04)
+- Ubuntu Server 22.04 (recommended)
 - Network interface `enp5s0` available on all nodes
-- Root or sudo access
-
-### Network Requirements
-- Static IPs configured for all nodes:
+- SSH enabled with sudo access
+- Static IPs configured:
   - Node 1: 192.168.68.21
   - Node 2: 192.168.68.22
   - Node 3: 192.168.68.23
@@ -24,120 +24,130 @@
 
 ## Installation Steps
 
-### 1. Install Required Tools
+### 1. Install Required Tools on MacBook
 
 ```bash
-# Install helmfile
-curl -Lo ./helmfile https://github.com/helmfile/helmfile/releases/latest/download/helmfile_linux_amd64
-chmod +x ./helmfile
-sudo mv ./helmfile /usr/local/bin/
+# Install Homebrew if not already installed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# Install kubectl
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-chmod +x ./kubectl
-sudo mv ./kubectl /usr/local/bin/
+# Install required tools
+brew install helm
+brew install helmfile
+brew install kubectl
+brew install kustomize
 
-# Install kustomize
-curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-sudo mv ./kustomize /usr/local/bin/
+# Install k3sup
+brew install k3sup
+
+# Verify installations
+helmfile --version
+kubectl version --client
+kustomize version
+k3sup version
 ```
 
-### 2. Install k3s
+### 2. Install k3s Cluster Using k3sup
 
-On the first node (192.168.68.21):
 ```bash
-curl -sfL https://get.k3s.io | sh -s - server \
-  --disable traefik \
-  --disable servicelb \
-  --tls-san 192.168.68.20 \
-  --node-ip 192.168.68.21 \
-  --advertise-address 192.168.68.21
+# Create a directory for your kubeconfig
+mkdir -p ~/.kube
+
+# Install first master node
+k3sup install \
+  --ip 192.168.68.21 \
+  --user ubuntu \
+  --k3s-extra-args "--disable traefik --disable servicelb --node-ip 192.168.68.21 --advertise-address 192.168.68.21 --tls-san 192.168.68.20" \
+  --k3s-version v1.27.7+k3s2 \
+  --context homelab \
+  --merge \
+  --local-path ~/.kube/config
+
+# Join second master node
+k3sup join \
+  --ip 192.168.68.22 \
+  --user ubuntu \
+  --server-ip 192.168.68.21 \
+  --server-user ubuntu \
+  --k3s-extra-args "--disable traefik --disable servicelb --node-ip 192.168.68.22 --advertise-address 192.168.68.22" \
+  --k3s-version v1.27.7+k3s2 \
+  --server
+
+# Join third master node
+k3sup join \
+  --ip 192.168.68.23 \
+  --user ubuntu \
+  --server-ip 192.168.68.21 \
+  --server-user ubuntu \
+  --k3s-extra-args "--disable traefik --disable servicelb --node-ip 192.168.68.23 --advertise-address 192.168.68.23" \
+  --k3s-version v1.27.7+k3s2 \
+  --server
 ```
 
-Get the node token:
-```bash
-sudo cat /var/lib/rancher/k3s/server/node-token
-```
-
-On the other nodes (192.168.68.22 and 192.168.68.23):
-```bash
-curl -sfL https://get.k3s.io | K3S_URL=https://192.168.68.21:6443 K3S_TOKEN=<NODE_TOKEN> sh -s - server \
-  --disable traefik \
-  --disable servicelb \
-  --node-ip <NODE_IP> \
-  --advertise-address <NODE_IP>
-```
-
-### 3. Deploy kube-vip
+### 3. Set Up Local Repository
 
 ```bash
-# Apply kube-vip configuration
+# Clone the repository
 git clone https://github.com/yourusername/homelab-test.git
 cd homelab-test
+
+# Deploy kube-vip
 kubectl apply -f cluster/base/kube-vip/
+
+# Wait for kube-vip to be ready
+kubectl -n kube-system wait pod -l name=kube-vip --for condition=ready --timeout=90s
 ```
 
 ### 4. Deploy Remaining Components
 
 ```bash
+# Initialize helm repositories
+helmfile repos
+
 # Deploy with helmfile
 helmfile sync
 ```
 
-### 5. Configure DNS
+### 5. Configure Local DNS Resolution
 
-You have several options for DNS configuration:
+You have several options for DNS configuration on your MacBook:
 
-#### Option 1: Using dnsmasq (Recommended for Production)
+#### Option 1: Using dnsmasq via Homebrew
 
-Add to your dnsmasq configuration (/etc/dnsmasq.conf or appropriate config directory):
-```
-# Option A: Single domain
-address=/test.fanen.dk/10.0.10.2
-
-# Option B: Wildcard for all *.fanen.dk subdomains
-address=/.fanen.dk/10.0.10.2
-```
-
-Restart dnsmasq after making changes:
 ```bash
-sudo systemctl restart dnsmasq
+# Install dnsmasq
+brew install dnsmasq
+
+# Create config directory if it doesn't exist
+mkdir -p $(brew --prefix)/etc/dnsmasq.d
+
+# Add configuration for fanen.dk domain
+echo 'address=/.fanen.dk/10.0.10.2' >> $(brew --prefix)/etc/dnsmasq.d/fanen.dk.conf
+
+# Start dnsmasq service
+sudo brew services start dnsmasq
+
+# Configure macOS to use dnsmasq for .dk domains
+sudo mkdir -p /etc/resolver
+echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/dk
 ```
 
 #### Option 2: Using nip.io for Quick Testing
 
-If you don't want to configure DNS, you can use nip.io for immediate testing. Update your ingress host to:
+No configuration needed, just update your ingress host in `cluster/base/apps/test-website/ingress.yaml` to:
 ```yaml
 host: test-10-0-10-2.nip.io
 ```
 
-This will automatically resolve to 10.0.10.2 without any DNS configuration.
+#### Option 3: Local /etc/hosts file
 
-#### Option 3: Local hosts file
-
-Add to /etc/hosts:
-```
-10.0.10.2 test.fanen.dk
+```bash
+echo '10.0.10.2 test.fanen.dk' | sudo tee -a /etc/hosts
 ```
 
 ### 6. Update Application Ingress
 
-Depending on your chosen DNS option, update the IngressRoute in `cluster/base/apps/test-website/ingress.yaml`:
-
-```yaml
-# For dnsmasq or /etc/hosts
-spec:
-  routes:
-    - match: Host(`test.fanen.dk`)
-
-# OR for nip.io
-spec:
-  routes:
-    - match: Host(`test-10-0-10-2.nip.io`)
-```
-
-Apply the changes:
 ```bash
+# Apply the updated ingress configuration
 kubectl apply -f cluster/base/apps/test-website/ingress.yaml
 ```
 
@@ -145,22 +155,24 @@ kubectl apply -f cluster/base/apps/test-website/ingress.yaml
 
 ### 1. Check Cluster Status
 ```bash
+# Verify nodes are ready
 kubectl get nodes
-kubectl get pods --all-namespaces
+
+# Check all pods
+kubectl get pods -A
 ```
 
 ### 2. Verify High Availability
 ```bash
 # Test API server through VIP
-kubectl --server https://192.168.68.20:6443 get nodes
+KUBECONFIG=~/.kube/config kubectl --server https://192.168.68.20:6443 get nodes
 ```
 
 ### 3. Test DNS Resolution
 
-Test your DNS configuration:
 ```bash
 # For dnsmasq setup
-dig test.fanen.dk
+dig test.fanen.dk @127.0.0.1
 
 # For nip.io
 dig test-10-0-10-2.nip.io
@@ -173,21 +185,38 @@ curl -I http://test.fanen.dk  # or your chosen domain
 
 ### Common Issues
 
-1. Control plane VIP not accessible:
+1. SSH Connection Issues:
+   - Verify SSH key is properly set up
+   - Check if you can SSH manually to each node
+   - Ensure correct username is used
+
+2. Control plane VIP not accessible:
    - Verify kube-vip pods are running
    - Check network interface name matches configuration
    - Ensure IP is not used by another device
 
-2. Website not accessible:
+3. DNS resolution not working:
+   - For dnsmasq: check if service is running `brew services list`
+   - Verify resolver configuration: `cat /etc/resolver/dk`
+   - Try flushing DNS cache: `sudo killall -HUP mDNSResponder`
+
+4. Website not accessible:
    - Verify Traefik pods are running
    - Check LoadBalancer IP assignment
    - Verify DNS resolution
 
-### Logs
+### Logs and Debugging
 ```bash
 # Check kube-vip logs
 kubectl logs -n kube-system -l app=kube-vip
 
 # Check Traefik logs
 kubectl logs -n traefik -l app.kubernetes.io/name=traefik
+
+# Test DNS resolution
+dig test.fanen.dk @127.0.0.1
+scutil --dns
+
+# Check dnsmasq configuration
+cat $(brew --prefix)/etc/dnsmasq.d/fanen.dk.conf
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ mkdir -p ~/.kube
 # Install first master node
 k3sup install \
   --ip 192.168.68.21 \
-  --user ubuntu \
+  --user skjoedt \
   --k3s-extra-args "--disable traefik --disable servicelb --node-ip 192.168.68.21 --advertise-address 192.168.68.21 --tls-san 192.168.68.20" \
   --k3s-version v1.27.7+k3s2 \
   --context homelab \
@@ -65,7 +65,7 @@ k3sup install \
 # Join second master node
 k3sup join \
   --ip 192.168.68.22 \
-  --user ubuntu \
+  --user skjoedt \
   --server-ip 192.168.68.21 \
   --server-user ubuntu \
   --k3s-extra-args "--disable traefik --disable servicelb --node-ip 192.168.68.22 --advertise-address 192.168.68.22" \
@@ -75,7 +75,7 @@ k3sup join \
 # Join third master node
 k3sup join \
   --ip 192.168.68.23 \
-  --user ubuntu \
+  --user skjoedt \
   --server-ip 192.168.68.21 \
   --server-user ubuntu \
   --k3s-extra-args "--disable traefik --disable servicelb --node-ip 192.168.68.23 --advertise-address 192.168.68.23" \
@@ -86,10 +86,6 @@ k3sup join \
 ### 3. Set Up Local Repository
 
 ```bash
-# Clone the repository
-git clone https://github.com/yourusername/homelab-test.git
-cd homelab-test
-
 # Deploy kube-vip
 kubectl apply -f cluster/base/kube-vip/
 


### PR DESCRIPTION
This PR updates the installation guide to use k3sup for remote installation from a MacBook. Key changes include:

1. MacBook-specific Prerequisites
   - Required tools installation using Homebrew
   - Local DNS configuration options

2. Remote Installation Process
   - k3sup for remote k3s installation
   - Step-by-step SSH-based deployment
   - Version-locked k3s installation (v1.27.7+k3s2)

3. Local DNS Configuration Options
   - dnsmasq setup via Homebrew
   - nip.io alternative
   - /etc/hosts option

4. MacBook-specific Troubleshooting
   - SSH connectivity issues
   - Local DNS resolution
   - Cache clearing commands
   - Debugging tools

5. Enhanced Verification Steps
   - Local kubeconfig handling
   - DNS verification
   - Service accessibility testing

The guide now allows users to manage the entire cluster deployment process from their MacBook without needing to directly access the nodes beyond SSH.